### PR TITLE
make sure register for push is in main thread

### DIFF
--- a/Source/Channel/Channel.m
+++ b/Source/Channel/Channel.m
@@ -80,7 +80,11 @@ static BOOL coldStartFromTappingOnPushNotification = NO;
 
 +(void)setupWithApplicationId:(NSString *)appId userID:(NSString *)userID userData:(NSDictionary *)userData launchOptions:(NSDictionary *)launchOptions {
     [CHConfiguration sharedConfiguration].applicationId = appId;
-    [Channel registerForPushNotifications];
+  
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [Channel registerForPushNotifications];
+    });
+    
     if (userID != nil) {
         [CHClient currentClient].userID = userID;
     }


### PR DESCRIPTION
From a reported crash.
[UIApplication registerForRemoteNotifications] must be used from main thread only.



